### PR TITLE
no-matlab option patch

### DIFF
--- a/cibrrig/postprocess/optotag.py
+++ b/cibrrig/postprocess/optotag.py
@@ -528,6 +528,7 @@ def run_probe(probe_path, tags, consideration_window, wavelength, plot=False,no_
     else:
         p_stat = np.ones_like(cluster_ids)*np.nan
         I_stat = np.ones_like(cluster_ids)*np.nan
+        salt_rez = None  # ensure it's defined
 
     # Compute heuristic data
     n_stims_with_spikes, base_rate, stim_rate = compute_tagging_summary(


### PR DESCRIPTION
if no-matlab option is selected then salt-rez never got defined resulting in an error.